### PR TITLE
Prototype: feat: Add support for Kubernetes deployment

### DIFF
--- a/discovery/templates/NOTES.txt
+++ b/discovery/templates/NOTES.txt
@@ -9,4 +9,28 @@ Discovery Deployment:
 
 To get the Discovery Console URL run the following commands:
 
+{{- if eq (include "discovery.isOpenShift" .) "true" -}}
     echo "https://$(kubectl --namespace {{ .Release.Namespace }} get route/{{ .Release.Name }} -o 'jsonpath={.spec.host}')"
+{{- else -}}
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "discovery.serverFullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "discovery.serverFullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "discovery.serverFullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "discovery.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
+{{- end }}

--- a/discovery/templates/_discovery.tpl
+++ b/discovery/templates/_discovery.tpl
@@ -25,3 +25,14 @@ Define the cluster local fully qualified host for redis
 {{- define "discovery.redis-host" -}}
 {{ printf "%s-redis.%s.svc.cluster.local" (.Release.Name) (.Release.Namespace) }}
 {{- end }}
+
+{{/*
+Define the boolean to tell us if we're targetting OpenShift
+*/}}
+{{- define "discovery.isOpenShift" -}}
+{{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" -}}
+{{ printf "true" }}
+{{- else -}}
+{{ printf "false" }}
+{{- end }}
+{{- end }}

--- a/discovery/templates/ingress.yaml
+++ b/discovery/templates/ingress.yaml
@@ -1,0 +1,63 @@
+{{- if eq (include "discovery.isOpenShift" .) "false" -}}
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := (include "discovery.serverFullname" .) -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "discovery.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/discovery/templates/route.yaml
+++ b/discovery/templates/route.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "discovery.isOpenShift" .) "true" -}}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -16,3 +17,4 @@ spec:
     name: {{ include "discovery.serverFullname" . }}
     weight: 100
   wildcardPolicy: None
+{{- end -}}

--- a/discovery/values.yaml
+++ b/discovery/values.yaml
@@ -28,6 +28,8 @@ podLabels: {}
 
 podSecurityContext:
   runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
   allowPrivilegeEscalation: false
   capabilities:
     drop: ["ALL"]
@@ -40,20 +42,18 @@ service:
   port: "8443"
 
 ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  enabled: true
+  className: "nginx"
+  annotations:
+    kubernetes.io/tls-acme: "true"
   hosts:
-    - host: chart-example.local
+    - host: "discovery.local"
       paths:
         - path: /
           pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+  tls:
+    - hosts:
+      - discovery.local
 
 pvc:
   data:
@@ -106,6 +106,8 @@ celery-worker:
     pullPolicy: Always
   podSecurityContext:
     runAsNonRoot: true
+    runAsUser: 1001
+    runAsGroup: 1001
     allowPrivilegeEscalation: false
     capabilities:
       drop: ["ALL"]


### PR DESCRIPTION
- Differentiating OpenShift vs Kubernetes via presence of OpenShift Route.
- Keeping the Route installation on OpenShift
- Installing an Ingress in case of Kubernetes
- Updates to Notes accordingly.

DRAFT:

Open Issues:
- [x] deploy with runAsNonRoot to false as follows:
```
      $ helm install discovery ./discovery --set server.password=superadmin1 \
         --set celery-worker.autoscaling.enabled=false \
         --set celery-worker.podSecurityContext.runAsNonRoot=false \
         --set podSecurityContext.runAsNonRoot=false \
         --set redis.podSecurityContext.runAsNonRoot=false
```

Above is resolved by add a `runAsUser` and `runAsGroup` for the server and celery-worker pod security contexts.

- [x] Services are not accessible via DNS (_svc.cluster.local_), might need to enable another addon.
```
      $ oc logs pods/discovery-celery-worker-95bd7745b-9gwsp
      ...
ERROR 2024-01-03 16:52:02,105 consumer 21 140263690725184 consumer:
Cannot connect to redis://:**@discovery-redis.discovery-helm.svc.cluster.local:6379//:
Error 111 connecting to discovery-redis.discovery-helm.svc.cluster.local:6379.
Connection refused..
      ...
```

coredns is working fine and the database is being accessed as such:

```
abellotti $ oc logs deployment/coredns -n kube-system 
...
[INFO] 10.244.0.84:49282 - 9528 "AAAA IN discovery-db.discovery-helm.svc.cluster.local. udp 63 false 512" NOERROR qr,aa,rd 156 0.000054705s
[INFO] 10.244.0.84:49282 - 11578 "A IN discovery-db.discovery-helm.svc.cluster.local. udp 63 false 512" NOERROR qr,aa,rd 124 0.000075778s
```

discovery-server is accessing the database via svc.cluster.local, so it's redis specific.

red herring?

```
[root@discovery-celery-worker-95bd7745b-qt8fq app]# env | grep redis
REDIS_HOST=discovery-redis.discovery-helm.svc.cluster.local
[root@discovery-celery-worker-95bd7745b-qt8fq app]# ssh $REDIS_HOST -p 6379
^C
[root@discovery-celery-worker-95bd7745b-qt8fq app]# ssh -v $REDIS_HOST -p 6379
OpenSSH_8.7p1, OpenSSL 3.0.7 1 Nov 2022
debug1: Reading configuration data /etc/ssh/ssh_config
debug1: Reading configuration data /etc/ssh/ssh_config.d/50-redhat.conf
debug1: Reading configuration data /etc/crypto-policies/back-ends/openssh.config
debug1: configuration requests final Match pass
debug1: re-parsing configuration
debug1: Reading configuration data /etc/ssh/ssh_config
debug1: Reading configuration data /etc/ssh/ssh_config.d/50-redhat.conf
debug1: Reading configuration data /etc/crypto-policies/back-ends/openssh.config
debug1: Connecting to discovery-redis.discovery-helm.svc.cluster.local [10.110.20.184] port 6379.
debug1: Connection established.
debug1: identity file /root/.ssh/id_rsa type -1
debug1: identity file /root/.ssh/id_rsa-cert type -1
debug1: identity file /root/.ssh/id_dsa type -1
debug1: identity file /root/.ssh/id_dsa-cert type -1
debug1: identity file /root/.ssh/id_ecdsa type -1
debug1: identity file /root/.ssh/id_ecdsa-cert type -1
debug1: identity file /root/.ssh/id_ecdsa_sk type -1
debug1: identity file /root/.ssh/id_ecdsa_sk-cert type -1
debug1: identity file /root/.ssh/id_ed25519 type -1
debug1: identity file /root/.ssh/id_ed25519-cert type -1
debug1: identity file /root/.ssh/id_ed25519_sk type -1
debug1: identity file /root/.ssh/id_ed25519_sk-cert type -1
debug1: identity file /root/.ssh/id_xmss type -1
debug1: identity file /root/.ssh/id_xmss-cert type -1
debug1: Local version string SSH-2.0-OpenSSH_8.7
debug1: kex_exchange_identification: banner line 0: -ERR unknown command `SSH-2.0-OpenSSH_8.7`, with args beginning with: 
```

- [x] for the test minikube, the `discovery-pull-secret` needed credentials for both `quay.io` and `registry.redhat.io` to pull all things. For now manually updated the secret, but would be nice if the `make create-pull-secret` support adding entries for multiple registries.
     - Solved with: https://github.com/quipucords/quipucords-helm-chart/pull/6

So far with this PR `Discovery` installs but still not usable due to open issues.

<img width="1512" alt="image" src="https://github.com/quipucords/quipucords-helm-chart/assets/5797328/4a9aedcb-8fd1-4237-b9d0-831219e722e0">

- [ ] Retest with OpenShift to make sure we didn't break its support.
