### PR TITLE
feat: Support creation of a pull secret with multiple docker servers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,25 +45,7 @@ uninstall:
 	fi
 
 create-pull-secret:
-	@pull_secret="discovery-pull-secret"; \
-	default="quay.io"; \
-	reg_server=$$(read -p "Registry server - $$default: " server; echo $$server); \
-	reg_server=$${reg_server:-$$default}; \
-	\
-	default="$$(whoami)"; \
-	reg_username=$$(read -p "Registry username - $$default: " username; echo $$username); \
-	reg_username=$${reg_username:-$$default}; \
-	\
-	reg_password=$$(read -s -p "Registry password: " pwd; echo $$pwd); \
-	stty echoe; echo; \
-	\
-	default="$${reg_username}@redhat.com"; \
-	reg_email=$$(read -p "Registry user e-mail - $$default: " email; echo $$email); \
-	reg_email=$${reg_email:-$$default}; \
-	\
-	echo "Creating $${reg_server} $${pull_secret} for $${reg_username} ..."; \
-	oc delete secret/$${pull_secret} --ignore-not-found=true; \
-	oc create secret docker-registry $${pull_secret} --docker-server="$${reg_server}" --docker-username="$${reg_username}" --docker-password="$${reg_password}" --docker-email="$${reg_email}"
+	@create_pull_secret.sh "discovery-pull-secret"
 
 help:
 	@echo "Makefile for the Discovery Helm Chart."

--- a/create_pull_secret.sh
+++ b/create_pull_secret.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Helper script to create a pull secret with one or more docker servers.
+#
+if [ $# -ne 1 ]; then
+  echo "Usage: ${0} <pull-secret-name>"
+  exit 1
+fi
+
+pull_secret="${1}"
+config_json='{"auths":{}}'
+
+while :
+do
+  default="quay.io"
+  echo
+  reg_server=$(read -p "Registry server - $default: " server; echo $server)
+  reg_server=${reg_server:-$default}
+
+  default="$(whoami)"
+  reg_username=$(read -p "Registry username - $default: " username; echo $username)
+  reg_username=${reg_username:-$default}
+
+  reg_password=$(read -s -p "Registry password: " pwd; echo $pwd)
+  stty echoe; echo
+
+  default="${reg_username}"
+  [[ ! "${default}" =~ "@" ]] && default="${default}@redhat.com"
+
+  reg_email=$(read -p "Registry user e-mail - $default: " email; echo $email)
+  reg_email=${reg_email:-$default}
+
+  config_json=`echo ${config_json} | jq ".auths += {\"${reg_server}\":{\"username\":\"${reg_username}\",\"password\":\"${reg_password}\",\"email\":\"${reg_email}\"}}"`
+
+  echo
+  another=$(read -p "Add another docker server (y/n)?" ans; echo $ans)
+  if [ ! "${another}" = "y" ]; then
+    break
+  fi
+done
+
+config_json_file="$(mktemp)"
+echo -n "${config_json}" > "${config_json_file}"
+echo
+echo "Creating pull secret ${pull_secret} ..."
+oc delete secret/${pull_secret} --ignore-not-found=true
+oc create secret generic ${pull_secret} \
+  --from-file=.dockerconfigjson="${config_json_file}" \
+  --type=kubernetes.io/dockerconfigjson
+rm -f "${config_json_file}"
+


### PR DESCRIPTION
In some environments, we need to support different docker server entries in the discovery pull secret, i.e. quay.io, registry.redhat.io, etc.

Moving the create pull secret out of the Makefile into its own script and calling the same from the Makefile.