### PR TITLE
chore: Bumping Chart to 0.9.6 to pull in Discovery 1.6.1

### DIFF
--- a/discovery/Chart.yaml
+++ b/discovery/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.5
+version: 0.9.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.5.3"
+appVersion: "1.6.1"
 
 # The Discovery Product Icon
 icon: https://quipucords.github.io/quipucords-helm-repo/charts/discovery/icon.png
@@ -33,4 +33,4 @@ dependencies:
   - name: redis
     version: 1.0.0
   - name: celery-worker
-    version: 0.9.5
+    version: 0.9.6

--- a/discovery/charts/celery-worker/Chart.yaml
+++ b/discovery/charts/celery-worker/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.5
+version: 0.9.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.5.3"
+appVersion: "1.6.1"

--- a/discovery/values.yaml
+++ b/discovery/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 
 image:
   repository: "quay.io/quipucords/quipucords"
-  tag: "1.5.3"
+  tag: "1.6.1"
   pullPolicy: Always
 
 # The image for the Discovery server
@@ -104,7 +104,7 @@ ansible:
 celery-worker:
   image:
     repository: "quay.io/quipucords/quipucords"
-    tag: "1.5.3"
+    tag: "1.6.1"
     pullPolicy: Always
   podSecurityContext:
     runAsNonRoot: true


### PR DESCRIPTION
- Bumping the Helm Chart version to 0.9.6 to pull in the Discovery appVersion of 1.6.1 for both server and celery-worker.