### PR TITLE
chore: Bumping Chart to 0.9.6 to expose maxReplicas

### DIFF
--- a/discovery/Chart.yaml
+++ b/discovery/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.5
+version: 0.9.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -33,4 +33,4 @@ dependencies:
   - name: redis
     version: 1.0.0
   - name: celery-worker
-    version: 0.9.5
+    version: 0.9.6

--- a/discovery/charts/celery-worker/Chart.yaml
+++ b/discovery/charts/celery-worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.5
+version: 0.9.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/discovery/values.schema.json
+++ b/discovery/values.schema.json
@@ -65,6 +65,11 @@
                             "type": "integer",
                             "minimum": 1,
                             "maximum": 32
+                        },
+                        "maxReplicas": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 32
                         }
                     }
                 }


### PR DESCRIPTION
- Expose the maxReplicas for celery worker in the OCP Form.