### PR TITLE
chore: Bumping Chart to 0.9.7

### DIFF
--- a/discovery/Chart.yaml
+++ b/discovery/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.6
+version: 0.9.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.5.3"
+appVersion: "1.7.0"
 
 # The Discovery Product Icon
 icon: https://quipucords.github.io/quipucords-helm-repo/charts/discovery/icon.png
@@ -33,4 +33,4 @@ dependencies:
   - name: redis
     version: 1.0.0
   - name: celery-worker
-    version: 0.9.6
+    version: 0.9.7

--- a/discovery/charts/celery-worker/Chart.yaml
+++ b/discovery/charts/celery-worker/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.6
+version: 0.9.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.5.3"
+appVersion: "1.7.0"

--- a/discovery/templates/deployment.yaml
+++ b/discovery/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
               timeoutSeconds: 1
           readinessProbe:
               httpGet:
-                path: /api/v1/status/
+                path: /api/v1/ping/
                 port: {{ .Values.service.port }}
                 scheme: HTTPS
                 httpHeaders:

--- a/discovery/values.yaml
+++ b/discovery/values.yaml
@@ -4,7 +4,7 @@ replicaCount: 1
 
 image:
   repository: "quay.io/quipucords/quipucords"
-  tag: "1.5.3"
+  tag: "1.7.0"
   pullPolicy: Always
 
 # The image for the Discovery server
@@ -104,7 +104,7 @@ ansible:
 celery-worker:
   image:
     repository: "quay.io/quipucords/quipucords"
-    tag: "1.5.3"
+    tag: "1.7.0"
     pullPolicy: Always
   podSecurityContext:
     runAsNonRoot: true


### PR DESCRIPTION
- Include Quipucords 1.7.0
- Updated readiness probe to use the new ping endpoint