### PR TITLE
chore: Bumping Chart to 0.9.7

### DIFF
--- a/discovery/charts/celery-worker/templates/deployment.yaml
+++ b/discovery/charts/celery-worker/templates/deployment.yaml
@@ -84,8 +84,14 @@ spec:
                 secretKeyRef:
                   key: django-secret-key
                   name: {{ .Release.Name }}-secrets
+            - name: QPC_DBMS_HOST
+              value: {{ include "discovery.db-host" . }}
+            - name: QPC_DBMS_PORT
+              value: {{ .Values.global.dbPort | quote }}
             - name: REDIS_HOST
               value: {{ include "discovery.redis-host" . }}
+            - name: REDIS_PORT
+              value: {{ .Values.global.redisPort | quote }}
             - name: REDIS_PASSWORD
               value: {{ .Values.global.redisPassword }}
             - name: QPC_ENABLE_CELERY_SCAN_MANAGER

--- a/discovery/templates/deployment.yaml
+++ b/discovery/templates/deployment.yaml
@@ -71,6 +71,9 @@ spec:
             name: {{ .Release.Name }}-data-volume-claim
           - mountPath: /var/log
             name: {{ .Release.Name }}-log-volume-claim
+          - mountPath: /etc/ssl/qpc
+            name: {{ .Release.Name }}-data-volume-claim
+            subPath: certs
           env:
             - name: ANSIBLE_REMOTE_TMP
               value: {{ .Values.ansible.remoteTmp }}
@@ -94,7 +97,7 @@ spec:
             - name: QPC_DBMS_PASSWORD
               value: {{ .Values.db.postgresql.password }}
             - name: QPC_DBMS_PORT
-              value: {{ .Values.db.service.port | quote }}
+              value: {{ .Values.global.dbPort | quote }}
             - name: QPC_DBMS_USER
               value: {{ .Values.db.postgresql.user }}
             - name: QPC_SERVER_PORT
@@ -118,6 +121,8 @@ spec:
               value: {{ .Values.server.log.allEnvVarsAtStartup | quote }}
             - name: REDIS_HOST
               value: {{ include "discovery.redis-host" . }}
+            - name: REDIS_PORT
+              value: {{ .Values.global.redisPort | quote }}
             - name: REDIS_PASSWORD
               value: {{ .Values.global.redisPassword }}
             - name: QPC_ENABLE_CELERY_SCAN_MANAGER

--- a/discovery/values.yaml
+++ b/discovery/values.yaml
@@ -138,8 +138,6 @@ redis:
       drop: ["ALL"]
     seccompProfile:
       type: "RuntimeDefault"
-  service:
-    port: "6379"
 
 # Discovery PostgreSQL Sub-chart
 db:
@@ -152,8 +150,6 @@ db:
       drop: ["ALL"]
     seccompProfile:
       type: "RuntimeDefault"
-  service:
-    port: "5432"
   postgresql:
     database: "qpc"
     user: "qpc"
@@ -163,6 +159,10 @@ db:
 global:
   # the Redis service password
   redisPassword: "qpc"
+  # the Redis service port
+  redisPort: "6379"
+  # the Db service port
+  dbPort: "5432"
   # The pullSecret for the discovery
   imagePullSecrets:
   - name: discovery-pull-secret


### PR DESCRIPTION
- Include Quipucords 1.7.0
- Updated readiness probe to use the new ping endpoint
- Submount /etc/ssl/qpc from the data volume as certs for the auto generated certs.
- make sure DB and Redis host and port are globally defined and available in server and celery worker.