### PR TITLE
fix: Fix celery worker resource limits

### DIFF
--- a/discovery/Chart.yaml
+++ b/discovery/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.7
+version: 0.9.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -33,4 +33,4 @@ dependencies:
   - name: redis
     version: 1.0.0
   - name: celery-worker
-    version: 0.9.7
+    version: 0.9.8

--- a/discovery/charts/celery-worker/Chart.yaml
+++ b/discovery/charts/celery-worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.7
+version: 0.9.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/discovery/charts/celery-worker/templates/deployment.yaml
+++ b/discovery/charts/celery-worker/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "celery-worker.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.autoscaling.minReplicas }}
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "celery-worker.selectorLabels" . | nindent 6 }}
@@ -57,21 +57,22 @@ spec:
                 - /bin/sh
                 - -c
                 - 'ps axo command | grep -v grep | grep /opt/venv/bin/python | grep worker'
+            failureThreshold: 3
             initialDelaySeconds: 30
-            timeoutSeconds: 5
-            periodSeconds: 5
-            failureThreshold: 5
+            periodSeconds: 10
             successThreshold: 1
+            timeoutSeconds: 1
           readinessProbe:
             exec:
               command:
                 - /bin/sh
                 - -c
                 - 'ps axo command | grep -v grep | grep /opt/venv/bin/python | grep worker'
+            failureThreshold: 3
             initialDelaySeconds: 20
-            timeoutSeconds: 5
-            periodSeconds: 3
+            periodSeconds: 10
             successThreshold: 1
+            timeoutSeconds: 1
           env:
             - name: ANSIBLE_REMOTE_TMP
               value: {{ .Values.ansible.remoteTmp }}

--- a/discovery/charts/celery-worker/values.yaml
+++ b/discovery/charts/celery-worker/values.yaml
@@ -17,7 +17,7 @@ fullnameOverride: ""
 autoscaling:
   enabled: true
   minReplicas: 3
-  maxReplicas: 32
+  maxReplicas: 8
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
 
@@ -59,12 +59,12 @@ ingress:
   #      - chart-example.local
 
 resources:
-  limits:
-    cpu: 100m
-    memory: 128Mi
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 200m
+    memory: 1536Mi
+  limits:
+    cpu: 400m
+    memory: 2048Mi
 
 nodeSelector: {}
 

--- a/discovery/values.yaml
+++ b/discovery/values.yaml
@@ -117,15 +117,18 @@ celery-worker:
     remoteTmp: "/var/data/tmp/ansible/remote"
     localTemp: "/var/data/tmp/ansible/local"
   autoscaling:
+    enabled: true
     minReplicas: 3
-    maxReplicas: 32
+    maxReplicas: 8
+    targetCPUUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
   resources:
     requests:
       cpu: 200m
-      memory: 512Mi
+      memory: 1536Mi
     limits:
       cpu: 400m
-      memory: 1024Mi
+      memory: 2048Mi
 
 # Discovery REDIS Sub-chart
 redis:


### PR DESCRIPTION
- Changed celery worker replicas from 3 to 8
- Updated celery worker memory requirements to handle its default usage.
- updated autoscaler defaults accordingly
- Updated chart to 0.9.8