### PR TITLE
fix: Chart 0.9.9, adding the sshkeys subpath in the Data volume.

### DIFF
--- a/discovery/Chart.yaml
+++ b/discovery/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.8
+version: 0.9.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -33,4 +33,4 @@ dependencies:
   - name: redis
     version: 1.0.0
   - name: celery-worker
-    version: 0.9.8
+    version: 0.9.9

--- a/discovery/charts/celery-worker/Chart.yaml
+++ b/discovery/charts/celery-worker/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.8
+version: 0.9.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/discovery/charts/celery-worker/templates/deployment.yaml
+++ b/discovery/charts/celery-worker/templates/deployment.yaml
@@ -49,6 +49,9 @@ spec:
             name: {{ .Release.Name }}-data-volume-claim
           - mountPath: /var/log
             name: {{ .Release.Name }}-log-volume-claim
+          - mountPath: /sshkeys
+            name: {{ .Release.Name }}-data-volume-claim
+            subPath: sshkeys
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           livenessProbe:

--- a/discovery/templates/deployment.yaml
+++ b/discovery/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
           - mountPath: /etc/ssl/qpc
             name: {{ .Release.Name }}-data-volume-claim
             subPath: certs
+          - mountPath: /sshkeys
+            name: {{ .Release.Name }}-data-volume-claim
+            subPath: sshkeys
           env:
             - name: ANSIBLE_REMOTE_TMP
               value: {{ .Values.ansible.remoteTmp }}


### PR DESCRIPTION
- Needed to add the sshkeys subpath in the Data volume to mount as /sshkeys in the server and celery worker.